### PR TITLE
Featue/show result

### DIFF
--- a/Triplan/build.gradle.kts
+++ b/Triplan/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
 	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
 	implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 	implementation ("com.fasterxml.jackson.core:jackson-databind")
+	implementation ("org.jetbrains.kotlinx:kotlinx-datetime:0.3.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/Triplan/build.gradle.kts
+++ b/Triplan/build.gradle.kts
@@ -14,6 +14,9 @@ plugins {
 	// - Hibernate가 사용하는 Reflection API에서 Entity를 만들기 위해 인자 없는 기본 생성자가 필요함
 	kotlin("plugin.noarg") version "1.7.22"
 	kotlin("kapt") version "1.8.21"
+
+	// 직렬화
+	kotlin("plugin.serialization") version "1.8.21"
 }
 
 allOpen {
@@ -72,7 +75,10 @@ dependencies {
 	testImplementation("org.springframework.graphql:spring-graphql-test")
 	testImplementation("org.springframework.security:spring-security-test")
 
-
+	// 직렬화
+	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+	implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+	implementation ("com.fasterxml.jackson.core:jackson-databind")
 }
 
 tasks.withType<KotlinCompile> {

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/controller/PlanController.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/controller/PlanController.kt
@@ -1,12 +1,13 @@
 package com.Triplan.Triplan.controller
 
-import com.Triplan.Triplan.domain.plan.Plan
 import com.Triplan.Triplan.domain.plan.dto.request.DayPlanRequestDto
 import com.Triplan.Triplan.domain.plan.dto.request.PlanRequestDto
 import com.Triplan.Triplan.service.PlanService
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.encodeToJsonElement
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.MutationMapping
-import org.springframework.graphql.data.method.annotation.QueryMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
@@ -17,7 +18,9 @@ class PlanController (val planService: PlanService){
     fun requestPlanInformation(
         @RequestBody @Argument request: PlanRequestDto,
         @RequestBody @Argument requests: List<DayPlanRequestDto>
-    ): Plan {
-        return planService.route(request, requests)
+    ): JsonElement {
+
+        val result = planService.route(request, requests)
+        return Json.encodeToJsonElement(result)
     }
 }

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/DayPlan.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/DayPlan.kt
@@ -5,8 +5,10 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
+import kotlinx.serialization.Serializable
 
 @Entity
+@Serializable
 class DayPlan {
 
     @Id

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/Plan.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/Plan.kt
@@ -1,10 +1,13 @@
 package com.Triplan.Triplan.domain.plan
 
 import com.Triplan.Triplan.domain.user.User
+import com.Triplan.Triplan.serialize.LocalDateConverter
 import jakarta.persistence.*
-import java.time.LocalDate
+import kotlinx.serialization.Serializable
+import kotlinx.datetime.LocalDate
 
 @Entity
+@Serializable
 class Plan {
 
     @Id
@@ -15,8 +18,10 @@ class Plan {
     @ManyToOne(fetch = FetchType.LAZY)
     var user: User? = null
 
+    @Convert(converter = LocalDateConverter::class)
     var startDate: LocalDate? = null
 
+    @Convert(converter = LocalDateConverter::class)
     var endDate: LocalDate? = null
 
     var touristArea: String? = null

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/TripPlace.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/TripPlace.kt
@@ -1,12 +1,16 @@
 package com.Triplan.Triplan.domain.plan
 
+import com.Triplan.Triplan.serialize.LocalDateTimeConverter
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
-import java.time.LocalDateTime
+import kotlinx.serialization.Serializable
+import kotlinx.datetime.LocalDateTime
 
 @Entity
+@Serializable
 class TripPlace {
 
     @Id
@@ -18,10 +22,14 @@ class TripPlace {
 
     var location: String? = null
 
-    var transitTime: LocalDateTime? = null
+    @Convert(converter = LocalDateTimeConverter::class)
+    var transitTime: LocalDateTime = LocalDateTime.parse(
+        java.time.LocalDateTime.now().toString()
+    )
 
     var transports: String? = null
 
+    @Convert(converter = LocalDateTimeConverter::class)
     var leadTime: LocalDateTime? = null
 
     var toll: Int = 0

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/dto/request/PlanRequestDto.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/plan/dto/request/PlanRequestDto.kt
@@ -1,6 +1,6 @@
 package com.Triplan.Triplan.domain.plan.dto.request
 
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 class PlanRequestDto {
 

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/user/User.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/domain/user/User.kt
@@ -2,6 +2,8 @@ package com.Triplan.Triplan.domain.user
 
 import com.Triplan.Triplan.domain.BaseTimeEntity
 import jakarta.persistence.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 
 @Entity
 @Table(
@@ -10,6 +12,7 @@ import jakarta.persistence.*
         UniqueConstraint(columnNames = ["socialId", "role"])
     ]
 )
+@Serializable(with = KSerializer::class)
 class User(
 
 
@@ -32,6 +35,7 @@ class User(
     @Column(name = "user_id")
     var id: Long = 0L
 
+    @Serializable
     companion object {
         fun createKakaoUser(kakaoId: String, email: String, img: String, nickname: String): User {
             return User(kakaoId, email, img, nickname, Role.KAKAO);

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/serialize/LocalDateConverter.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/serialize/LocalDateConverter.kt
@@ -1,0 +1,16 @@
+package com.Triplan.Triplan.serialize
+
+import jakarta.persistence.AttributeConverter
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toJavaLocalDate
+
+class LocalDateConverter():AttributeConverter<LocalDate, java.time.LocalDate> {
+
+    override fun convertToDatabaseColumn(attribute: LocalDate?): java.time.LocalDate? {
+        return attribute?.toJavaLocalDate()
+    }
+
+    override fun convertToEntityAttribute(dbData: java.time.LocalDate?): LocalDate {
+        return LocalDate.parse(dbData.toString())
+    }
+}

--- a/Triplan/src/main/kotlin/com/Triplan/Triplan/serialize/LocalDateTimeConverter.kt
+++ b/Triplan/src/main/kotlin/com/Triplan/Triplan/serialize/LocalDateTimeConverter.kt
@@ -1,0 +1,15 @@
+package com.Triplan.Triplan.serialize
+
+import jakarta.persistence.AttributeConverter
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toJavaLocalDate
+
+class LocalDateTimeConverter():AttributeConverter<LocalDate, java.time.LocalDate> {
+    override fun convertToDatabaseColumn(attribute: LocalDate?): java.time.LocalDate? {
+        return attribute?.toJavaLocalDate()
+    }
+
+    override fun convertToEntityAttribute(dbData: java.time.LocalDate?): LocalDate {
+        return LocalDate.parse(dbData.toString())
+    }
+}


### PR DESCRIPTION
## Serialization
백엔드의 로직 결과(`Plan`)를 프론트 엔드로 보낼 때 일렬화(serialization)이 필요해짐
  - `Plan`인스턴스의 참조를 바로 보냈더니 FE에서 받지 못하는 문제
  - 따라서 `Plan` 인스턴스를 일렬화 함 

`Kotlinx.serialization` 라이브러리와 `Kotlinx.datetime` 모듈을 사용하여 일렬화 적용
 
## Converter
JDBC에서 `Kotlinx.datetime` 내의  `LocalDate` 타입과 `LocalDateTime`타입을 지원하지 않음
이에 각 타입을 DB에 저장할 때 다시 Java에서 제공하는 `java.time.LocalDate`과 `java.time.LocalDateTime`으로 변경하는 기능의 @Convert를 사용
    - @Convert사용 시 필요한 Custom Converter를 구현


## Reviewers
@Tkfrnfl 
@eungyu625 